### PR TITLE
Chickenable instruction and data caches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "rocket-chip"]
 	path = generators/rocket-chip
-	url = https://github.com/chipsalliance/rocket-chip.git
+	url = https://github.com/ezhes/rocket-chip.git
 [submodule "testchipip"]
 	path = generators/testchipip
 	url = https://github.com/ezhes/testchipip.git


### PR DESCRIPTION
This PR adds chicken bits for the instruction and data caches. On reset, the chip starts with the I$ and D$ fully disabled. This means all accesses pass through to the external memory system. This is useful if it turns out the SRAMs are not reliable as the core will still be usable, albeit with greatly reduced performance (seeing around 14x slowdown). If the macros are okay, the bits can be cleared to enable caching. Once the caches are enabled, they should not be disabled again as it may cause unexpected and hard to understand data loss. 